### PR TITLE
fix(cypress-angular-dev-server): fixes error when using per project configuration files

### DIFF
--- a/packages/cypress-angular-dev-server/src/lib/find-target-options.ts
+++ b/packages/cypress-angular-dev-server/src/lib/find-target-options.ts
@@ -53,9 +53,12 @@ function _findOptions({
   /* Standalone project configuration case: */
   if (typeof workspaceDef?.projects?.[project] === 'string') {
     const standaloneDef = JSON.parse(
-      readFileSync(resolve(root, workspaceDef.projects[project]), {
-        encoding: 'utf-8',
-      })
+      readFileSync(
+        resolve(root, `${workspaceDef.projects[project]}/project.json`),
+        {
+          encoding: 'utf-8',
+        }
+      )
     );
 
     if (configuration) {

--- a/packages/cypress-angular-dev-server/src/lib/start-angular-dev-server.spec.ts
+++ b/packages/cypress-angular-dev-server/src/lib/start-angular-dev-server.spec.ts
@@ -5,7 +5,7 @@ import {
 import { describe, expect, it } from '@jest/globals';
 import { AngularWebpackPlugin } from '@ngtools/webpack';
 import { findTargetOptions } from './find-target-options';
-import { resolve } from 'path';
+import { normalize, resolve } from 'path';
 
 import { startAngularDevServer } from './start-angular-dev-server';
 
@@ -68,8 +68,8 @@ describe(startAngularDevServer.name, () => {
         expect.objectContaining({
           specs: [],
           config: expect.objectContaining({
-            configFile: expect.stringMatching(
-              /__tests__\/fixtures\/demo\/cypress.json$/
+            configFile: expect.stringContaining(
+              normalize('__tests__/fixtures/demo/cypress.json')
             ),
             version: '7.1.0',
             testingType: 'component',
@@ -81,7 +81,9 @@ describe(startAngularDevServer.name, () => {
         expect.arrayContaining([expect.any(AngularWebpackPlugin)])
       );
       /* Check config has rules. */
-      expect((webpackConfig as any).module.rules.length).toBeGreaterThanOrEqual(1);
+      expect((webpackConfig as any).module.rules.length).toBeGreaterThanOrEqual(
+        1
+      );
     });
   });
 
@@ -149,7 +151,7 @@ describe(startAngularDevServer.name, () => {
       );
 
       expect(plugin.options.tsconfig).toMatch(
-        /__tests__\/fixtures\/demo\/tsconfig.cypress.json$/
+        normalize('__tests__/fixtures/demo/tsconfig.cypress.json')
       );
     });
   });

--- a/packages/cypress-angular/src/generators/setup-ct/setup-ct.spec.ts
+++ b/packages/cypress-angular/src/generators/setup-ct/setup-ct.spec.ts
@@ -5,6 +5,7 @@ import {
   writeJson,
 } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { normalize } from 'path';
 
 import { SetupCtGeneratorSchema } from './schema';
 import { setupCtGenerator } from './setup-ct';
@@ -76,7 +77,7 @@ describe('setup-ct generator', () => {
       expect(tree.exists(tsconfigPath)).toBeTruthy();
       expect(readJson(tree, tsconfigPath)).toEqual(
         expect.objectContaining({
-          extends: '../../tsconfig.base.json',
+          extends: normalize('../../tsconfig.base.json'),
           compilerOptions: {
             allowSyntheticDefaultImports: true,
             types: ['cypress'],
@@ -93,9 +94,9 @@ describe('setup-ct generator', () => {
         expect.objectContaining({
           executor: '@nrwl/cypress:cypress',
           options: {
-            cypressConfig: 'libs/my-lib/cypress.json',
+            cypressConfig: normalize('libs/my-lib/cypress.json'),
             testingType: 'component',
-            tsConfig: 'libs/my-lib/tsconfig.cypress.json',
+            tsConfig: normalize('libs/my-lib/tsconfig.cypress.json'),
           },
         })
       );
@@ -116,9 +117,9 @@ describe('setup-ct generator', () => {
         expect.objectContaining({
           builder: '@nrwl/cypress:cypress',
           options: {
-            cypressConfig: 'libs/my-lib/cypress.json',
+            cypressConfig: normalize('libs/my-lib/cypress.json'),
             testingType: 'component',
-            tsConfig: 'libs/my-lib/tsconfig.cypress.json',
+            tsConfig: normalize('libs/my-lib/tsconfig.cypress.json'),
           },
         })
       );
@@ -126,11 +127,9 @@ describe('setup-ct generator', () => {
 
     it('should extend Angular CLI tsconfig.app.json', async () => {
       await setupLib({ cli: 'ng' });
-      expect(
-        readJson(tree, 'libs/my-lib/tsconfig.cypress.json')
-      ).toEqual(
+      expect(readJson(tree, 'libs/my-lib/tsconfig.cypress.json')).toEqual(
         expect.objectContaining({
-          extends: './tsconfig.app.json'
+          extends: './tsconfig.app.json',
         })
       );
     });
@@ -151,8 +150,8 @@ describe('setup-ct generator', () => {
 
     cli === 'nx'
       ? writeJson(tree, 'libs/my-lib/tsconfig.json', {})
-      /* Angular CLI tsconfig app configuration: */
-      : writeJson(tree, 'libs/my-lib/tsconfig.app.json', {});
+      : /* Angular CLI tsconfig app configuration: */
+        writeJson(tree, 'libs/my-lib/tsconfig.app.json', {});
 
     await setupCtGenerator(tree, {
       project: 'my-lib',


### PR DESCRIPTION
**Current Behavior**

When using per project configuration files an error is thrown and cypress cannot be started.

**Expected Behavior**

Cypress should be able to be started when using per project configuration files.

**Related Issue(s)**

Fixes #117 