### PR TITLE
Enable Strict mode

### DIFF
--- a/packages/operators/src/lib/suspensify.ts
+++ b/packages/operators/src/lib/suspensify.ts
@@ -27,6 +27,9 @@ export function suspensify<T, R>(
 ): OperatorFunction<T, R>;
 export function suspensify<T, R = Suspense<T>>(
   projector?: (data: Suspense<T>) => R
+): OperatorFunction<T, R | Suspense<T>>;
+export function suspensify<T, R = Suspense<T>>(
+  projector?: (data: Suspense<T>) => R
 ): OperatorFunction<T, R | Suspense<T>> {
   return (source$: Observable<T>): Observable<R | Suspense<T>> => {
     return source$.pipe(_suspensify(projector), _coalesceFirstEmittedValue());
@@ -60,9 +63,12 @@ function _suspensify<T, R>(
 ): OperatorFunction<T, R>;
 function _suspensify<T, R = Suspense<T>>(
   projector?: (data: Suspense<T>) => R
+): OperatorFunction<T, R | Suspense<T>>;
+function _suspensify<T, R = Suspense<T>>(
+  projector?: (data: Suspense<T>) => R
 ): OperatorFunction<T, R | Suspense<T>> {
   return (source$: Observable<T>): Observable<R | Suspense<T>> => {
-    const initialState = {
+    const initialState: Suspense<T> = {
       value: undefined,
       error: undefined,
       finalized: false,
@@ -91,7 +97,7 @@ function _suspensify<T, R = Suspense<T>>(
           finalized,
           pending: false,
         };
-      }, undefined),
+      }, initialState),
       startWith(initialState)
     );
 

--- a/packages/playwright-ct-angular/tsconfig.json
+++ b/packages/playwright-ct-angular/tsconfig.json
@@ -9,5 +9,8 @@
     {
       "path": "./tsconfig.spec.json"
     }
-  ]
+  ],
+  "compilerOptions": {
+    "strict":false
+  }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -43,7 +43,8 @@
       "@jscutlery/playwright-ct-angular": [
         "packages/playwright-ct-angular/src/index.ts"
       ]
-    }
+    },
+    "strict": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Hi 👋

I've tried to solve #99, here is a few side notes about the fix, let me know if something should have been implemented differently:

- In `suspensify.ts` I have explicitly overloaded `suspensify()`and `_suspensify()` with an optional `projector` arg. I don't know if that's an intended usage of the operator, but I guess it would create a breaking change to "remove" this overload from the operator's API
- In playwright-ct-angular, I've disabled the strict flag because the `_addRunnerPlugin` property from `@playwright/test` isn't exported in the types of the lib and the `@playwright/test/lib/mount` doesn't seems to have types either. Do you want me to create an issue in Playwright to ask if they are willing to fix that ?