### PR TITLE
fix: import of zone.js and zone.js/testing

### DIFF
--- a/apps/sandbox/src/polyfills.ts
+++ b/apps/sandbox/src/polyfills.ts
@@ -55,7 +55,7 @@
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js/dist/zone'; // Included with Angular CLI.
+import 'zone.js'; // Included with Angular CLI.
 
 /***************************************************************************************************
  * APPLICATION IMPORTS

--- a/packages/cypress-harness/src/support.ts
+++ b/packages/cypress-harness/src/support.ts
@@ -6,10 +6,10 @@ import 'cypress-pipe';
  * in `@angular/core/testing`.
  * Cf. https://github.com/jscutlery/devkit/issues/2
  */
-import 'zone.js/dist/zone';
+import 'zone.js';
 
 /* @hack fixes "Mocha has already been patched with Zone" error. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any)['Mocha']['__zone_patch__'] = false;
 
-import 'zone.js/dist/zone-testing';
+import 'zone.js/testing';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4826,11 +4826,15 @@ __metadata:
     rxjs: ^7.5.7
     vite: ^3.2.1
   peerDependencies:
-    "@angular/core": "*"
-    "@angular/platform-browser": "*"
-    "@angular/platform-browser-dynamic": "*"
-    "@playwright/test": ">=1.39.0"
+    "@angular/compiler": ^16.0.0 || ^17.0.0
+    "@angular/core": ^16.0.0 || ^17.0.0
+    "@angular/platform-browser": ^16.0.0 || ^17.0.0
+    "@angular/platform-browser-dynamic": ^16.0.0 || ^17.0.0
+    "@playwright/experimental-ct-core": ^1.39.0
+    "@playwright/test": ^1.39.0
+    rxjs: ^7.0.0
     tslib: "*"
+    zone.js: "*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Fixes #265 

This pull request adjusts how zone.js is imported in order to support Angular 17.

As noted in the [v17.0.0-next.5 pre-release](https://github.com/angular/angular/releases/tag/17.0.0-next.5):


> ### zone.js
> - Deep and legacy dist/ imports like zone.js/bundles/zone-testing.js and zone.js/dist/zone are no longer allowed. zone-> testing-bundle and zone-testing-node-bundle are also no longer part of the package.
> 
> The proper way to import zone.js and zone.js/testing is:
> ```ts
> import 'zone.js';
> import 'zone.js/testing';
> ```

Tests continue to run and pass without adjusting any package versions. Furthermore, via `npm link`, confirmed this change fixes running E2E in the reproduction repo mentioned in the linked issue.