### PR TITLE
feat/transform input alias

### DIFF
--- a/packages/swc-plugin-angular/src/input_visitor.rs
+++ b/packages/swc-plugin-angular/src/input_visitor.rs
@@ -18,33 +18,6 @@ pub struct InputVisitor {
     current_component: Atom,
 }
 
-struct InputInfo {
-    component: Atom,
-    name: Atom,
-    alias: Option<String>,
-    required: bool,
-}
-
-#[derive(Default)]
-struct InputOptionsVisitor {
-    alias: Option<String>,
-}
-
-impl Visit for InputOptionsVisitor {
-    fn visit_prop(&mut self, prop: &Prop) {
-        let key_value = match prop.as_key_value() {
-            Some(key_value) => key_value,
-            None => return,
-        };
-
-        if let Some(true) = key_value.key.as_ident().map(|key| key.sym.eq("alias")) {
-            if let Some(LitStr(str)) = key_value.value.as_lit() {
-                self.alias = Some(str.value.as_str().to_string());
-            }
-        }
-    }
-}
-
 impl VisitMut for InputVisitor {
     fn visit_mut_class_decl(&mut self, node: &mut swc_core::ecma::ast::ClassDecl) {
         self.current_component = node.ident.sym.clone();
@@ -116,6 +89,33 @@ impl VisitMut for InputVisitor {
                 value: "".into(),
                 raw: Some(raw.as_str().into()),
             }.into_stmt().into());
+        }
+    }
+}
+
+struct InputInfo {
+    component: Atom,
+    name: Atom,
+    alias: Option<String>,
+    required: bool,
+}
+
+#[derive(Default)]
+struct InputOptionsVisitor {
+    alias: Option<String>,
+}
+
+impl Visit for InputOptionsVisitor {
+    fn visit_prop(&mut self, prop: &Prop) {
+        let key_value = match prop.as_key_value() {
+            Some(key_value) => key_value,
+            None => return,
+        };
+
+        if let Some(true) = key_value.key.as_ident().map(|key| key.sym.eq("alias")) {
+            if let Some(LitStr(str)) = key_value.value.as_lit() {
+                self.alias = Some(str.value.as_str().to_string());
+            }
         }
     }
 }

--- a/tests/swc-plugin-angular-wide/src/test.component.spec.ts
+++ b/tests/swc-plugin-angular-wide/src/test.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, input } from '@angular/core';
+import { Component, input, Type } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 describe('swc-plugin-angular', () => {
@@ -22,6 +22,25 @@ describe('swc-plugin-angular', () => {
     const title = fixture.nativeElement.querySelector('h1');
     expect(title.textContent).toBe('Hello title!');
   });
+
+  it.todo('should pass aliased inputs to children', () => {
+    const { title } = render(AliasContainerComponent);
+    expect(title).toBe('Hello alias!');
+  });
+
+  it.todo('should pass required aliases inputs to children', () => {
+    const { title } = render(AliasRequiredContainerComponent);
+    expect(title).toBe('Hello alias!');
+  });
+
+  function render(cmpType: Type<unknown>) {
+    const fixture = TestBed.createComponent(cmpType);
+    fixture.autoDetectChanges();
+
+    return {
+      title: fixture.nativeElement.querySelector('h1')?.textContent
+    }
+  }
 });
 
 @Component({
@@ -52,4 +71,40 @@ class TitleComponent {
 class TestInputsComponent {
   title = 'Hello title!';
   body = 'Hello body!';
+}
+
+@Component({
+  standalone: true,
+  selector: 'lib-title',
+  template: `<h1>Hello {{ myTitle() }}!</h1>`,
+})
+class AliasTitleComponent {
+  myTitle = input<string | undefined>(undefined, {alias: 'title'});
+}
+
+@Component({
+  standalone: true,
+  imports: [AliasTitleComponent],
+  template: '<lib-title [title]="title"/>',
+})
+class AliasContainerComponent {
+  title = 'alias';
+}
+
+@Component({
+  standalone: true,
+  selector: 'lib-title',
+  template: `<h1>Hello {{ myTitle() }}!</h1>`,
+})
+class AliasRequiredTitleComponent {
+  myTitle = input.required<string>( {alias: 'title'});
+}
+
+@Component({
+  standalone: true,
+  imports: [AliasRequiredTitleComponent],
+  template: '<lib-title [title]="title"/>',
+})
+class AliasRequiredContainerComponent {
+  title = 'alias';
 }

--- a/tests/swc-plugin-angular-wide/src/test.component.spec.ts
+++ b/tests/swc-plugin-angular-wide/src/test.component.spec.ts
@@ -23,12 +23,12 @@ describe('swc-plugin-angular', () => {
     expect(title.textContent).toBe('Hello title!');
   });
 
-  it.todo('should pass aliased inputs to children', () => {
+  it('should pass aliased inputs to children', () => {
     const { title } = render(AliasContainerComponent);
     expect(title).toBe('Hello alias!');
   });
 
-  it.todo('should pass required aliases inputs to children', () => {
+  it('should pass required aliases inputs to children', () => {
     const { title } = render(AliasRequiredContainerComponent);
     expect(title).toBe('Hello alias!');
   });


### PR DESCRIPTION
- refactor(swc-plugin-angular): 🛠️parse input alias
- refactor(swc-plugin-angular): 🛠️reorder structs & impls by importance
- test(swc-plugin-angular): ✅ add wide test to inputs with aliases
