### PR TITLE
fix(swc-plugin-angular): 🐞 transform async/await

### DIFF
--- a/packages/swc-angular-preset/README.md
+++ b/packages/swc-angular-preset/README.md
@@ -89,13 +89,13 @@ In your vite configuration file (e.g., `vite.config.ts`), use the `unplugin-swc`
 preset: `swcAngularVitePreset`.
 
 ```js
-import { swcAngularVitePreset } from '@jscutlery/swc-angular-preset';
+import { swcAngularUnpluginOptions } from '@jscutlery/swc-angular-preset';
 import swc from 'unplugin-swc';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
   // ...
-  plugins: [swc.vite(swcAngularVitePreset())]
+  plugins: [swc.vite(swcAngularUnpluginOptions())]
   // ...
 });
 ```

--- a/packages/swc-angular-preset/src/index.ts
+++ b/packages/swc-angular-preset/src/index.ts
@@ -1,5 +1,4 @@
 import type { Config } from '@swc/core';
-import type { Options as UnpluginOptions } from 'unplugin-swc';
 
 export interface AngularPresetOptions {
   templateRawSuffix?: boolean;
@@ -44,7 +43,9 @@ export function swcAngularVitePreset() {
   });
 }
 
-export function swcAngularUnpluginOptions(): UnpluginOptions {
+export function swcAngularUnpluginOptions(): Config & {
+  tsconfigFile?: boolean;
+} {
   return {
     ...swcAngularVitePreset(),
     /* Since we are using SWC's env option, we need to disable the tsconfigFile option.

--- a/packages/swc-angular-preset/src/index.ts
+++ b/packages/swc-angular-preset/src/index.ts
@@ -1,4 +1,5 @@
 import type { Config } from '@swc/core';
+import type { Options as UnpluginOptions } from 'unplugin-swc';
 
 export interface AngularPresetOptions {
   templateRawSuffix?: boolean;
@@ -16,7 +17,6 @@ export function swcAngularPreset(options: AngularPresetOptions = {}): Config {
         legacyDecorator: true,
         decoratorMetadata: true,
       },
-      target: 'esnext',
       experimental: {
         plugins: [
           [
@@ -27,6 +27,9 @@ export function swcAngularPreset(options: AngularPresetOptions = {}): Config {
           ],
         ],
       },
+    },
+    env: {
+      include: ['transform-async-to-generator'],
     },
   };
 }
@@ -41,6 +44,21 @@ export function swcAngularVitePreset() {
   });
 }
 
+export function swcAngularUnpluginOptions(): UnpluginOptions {
+  return {
+    ...swcAngularVitePreset(),
+    /* Since we are using SWC's env option, we need to disable the tsconfigFile option.
+     * Otherwise `unpluggin-swc` will try to use the target from the tsconfig's `compilerOptions`,
+     * and make SWC produce the following error: "`env` and `jsc.target` cannot be used together".
+     *
+     * We could have added this extra option to `swcAngularVitePreset`, but forwarding any extra option
+     * to SWC will make SWC's configuration parser fail.
+     *
+     * Cf.  https://github.com/unplugin/unplugin-swc/issues/137 */
+    tsconfigFile: false,
+  };
+}
+
 interface SwcPluginAngularOptions {
   templateRawSuffix?: boolean;
 }
@@ -48,22 +66,4 @@ interface SwcPluginAngularOptions {
 /**
  * @deprecated Use {@link swcAngularVitePreset}, {@link swcAngularJestTransformer} or {@link swcAngularPreset} instead.
  */
-export default {
-  jsc: {
-    parser: {
-      syntax: 'typescript',
-      decorators: true,
-      dynamicImport: true,
-    },
-    transform: {
-      legacyDecorator: true,
-      decoratorMetadata: true,
-    },
-    target: 'esnext',
-    experimental: {
-      plugins: [
-        ['@jscutlery/swc-plugin-angular', {} satisfies SwcPluginAngularOptions],
-      ],
-    },
-  },
-} satisfies Config;
+export default swcAngularPreset();

--- a/tests/swc-plugin-angular-wide/src/swc-plugin-angular-fake-async.spec.ts
+++ b/tests/swc-plugin-angular-wide/src/swc-plugin-angular-fake-async.spec.ts
@@ -1,31 +1,12 @@
 /* eslint-disable @angular-eslint/component-class-suffix */
 
-import { Component, OnInit, signal } from '@angular/core';
 import { fakeAsync, tick } from '@angular/core/testing';
-import { createComponent } from './testing';
 
-describe('swc-plugin-angular: fakeAsync and tick', () => {
-  it('should render with fakeAsync and tick', fakeAsync(() => {
-    @Component({
-      standalone: true,
-      template: '<h1>Value: {{ value() }}</h1>',
-    })
-    class Container implements OnInit {
-      value = signal(0);
+describe('swc-plugin-angular: fakeAsync', () => {
+  /* Cf. https://github.com/jscutlery/devkit/issues/303 */
+  it('should work with fakeAsync + tick + async/await', fakeAsync(async () => {
+    await Promise.resolve();
 
-      ngOnInit() {
-        setTimeout(() => {
-          this.value.set(1);
-        }, 1000);
-      }
-    }
-
-    const { nativeElement } = createComponent(Container);
-    const heading = () => nativeElement.querySelector('h1')?.textContent;
-
-    expect(heading()).toBe('Value: 0');
-
-    tick(1000);
-    expect(heading()).toBe('Value: 1');
+    expect(() => tick()).not.toThrow();
   }));
 });

--- a/tests/swc-plugin-angular-wide/vite.config.ts
+++ b/tests/swc-plugin-angular-wide/vite.config.ts
@@ -4,10 +4,10 @@ import { defineConfig } from 'vite';
 
 /* @hack for some annoying reason, this file doesn't seem to be compiled
  * using our tsconfigs, so it is not aware of the tsconfig.base.json paths. */
-import { swcAngularVitePreset } from '../../packages/swc-angular-preset/src/index';
+import { swcAngularUnpluginOptions } from '../../packages/swc-angular-preset/src/index';
 
 export default defineConfig({
   root: __dirname,
   cacheDir: '../../node_modules/.vite/tests/swc-plugin-angular-wide',
-  plugins: [swc.vite(swcAngularVitePreset())]
+  plugins: [swc.vite(swcAngularUnpluginOptions())],
 });


### PR DESCRIPTION
We have to transform async/await to generators,
otherwise Zone.js will not trigger tick, so no CD when an awaited promise is resolved.
This also allows using `fakeAsync + tick`.

Closes #303
