### PR TITLE
fix(swc-angular): 🐞 fix stackblitz support

### DIFF
--- a/packages/swc-angular/src/index.spec.ts
+++ b/packages/swc-angular/src/index.spec.ts
@@ -1,4 +1,6 @@
 import { afterEach, expect, test, vi } from 'vitest';
+import { FileSystem } from './utils';
+import { join } from 'node:path';
 
 /**
  * Using an old version of `@swc/core` will simply crash with the following error:
@@ -48,13 +50,69 @@ test('should not throw an error when module is imported and version is ~1.4.0', 
   expect(process.exit).not.toHaveBeenCalledOnce();
 });
 
+test('should fallback to package.json if version is not available (this happens on stackblitz)', async () => {
+  const { fileSystem } = setUp();
+
+  vi.doMock('@swc/core', () => ({
+    version: undefined,
+  }));
+  fileSystem.setJsonFile('node_modules/@swc/core/package.json', {
+    version: '1.4.0',
+  });
+
+  await import('./index');
+
+  expect(console.error).not.toHaveBeenCalledOnce();
+  expect(process.exit).not.toHaveBeenCalledOnce();
+});
+
+test('should throw an error if version from package.json is not compatible', async () => {
+  const { fileSystem } = setUp();
+
+  vi.doMock('@swc/core', () => ({
+    version: undefined,
+  }));
+  fileSystem.setJsonFile('node_modules/@swc/core/package.json', {
+    version: '1.3.0',
+  });
+
+  await import('./index');
+
+  expect(console.error).toHaveBeenCalledWith(
+    expect.stringContaining(
+      `@swc/core version 1.3.0 is incompatible with @jscutlery/swc-angular`,
+    ),
+  );
+});
+
 function setUp() {
+  const fileSystem = new FileSystemFake();
   vi.resetModules();
+  vi.doMock('./utils', () => ({
+    fileSystem,
+  }));
   vi.spyOn(console, 'error').mockReturnValue();
   vi.spyOn(process, 'exit').mockReturnValue(undefined as never);
+  return { fileSystem };
 }
 
 afterEach(() => {
   vi.restoreAllMocks();
   vi.resetModules();
 });
+
+class FileSystemFake implements FileSystem {
+  #jsonFiles = new Map<string, any>();
+  #workspaceRoot = join(__dirname, '../../..');
+
+  readJsonFile(path: string) {
+    return this.#jsonFiles.get(path);
+  }
+
+  /**
+   * Set the content of a JSON file using the workspace root as the base path.
+   */
+  setJsonFile(path: string, content: any) {
+    this.#jsonFiles.set(join(this.#workspaceRoot, path), content);
+  }
+}

--- a/packages/swc-angular/src/index.ts
+++ b/packages/swc-angular/src/index.ts
@@ -1,7 +1,9 @@
 import type { Config } from '@swc/core';
-import { version as swcCoreVersion } from '@swc/core';
+import { version } from '@swc/core';
+import { fileSystem } from './utils';
+import { dirname, join } from 'node:path';
 
-assertCompatibleSwcCoreVersion();
+assertCompatibleSwcCoreVersion(version);
 
 export interface AngularPresetOptions {
   templateRawSuffix?: boolean;
@@ -72,10 +74,22 @@ interface SwcPluginAngularOptions {
  */
 export default swcAngularPreset();
 
-function assertCompatibleSwcCoreVersion() {
-  if (!swcCoreVersion.startsWith('1.4.')) {
+function assertCompatibleSwcCoreVersion(version: string) {
+  /* Fallback to reading version from package.json when not exported.
+   * This happens on Stackblitz. */
+  if (version == undefined) {
+    const packageJsonPath = join(
+      dirname(require.resolve('@swc/core')),
+      'package.json',
+    );
+    version = fileSystem.readJsonFile<{
+      version: string;
+    }>(packageJsonPath).version;
+  }
+
+  if (!version.startsWith('1.4.')) {
     console.error(`
-    @swc/core version ${swcCoreVersion} is incompatible with @jscutlery/swc-angular.
+    @swc/core version ${version} is incompatible with @jscutlery/swc-angular.
     Please use @swc/core version 1.4.x.
     > npm add -D @swc/core@~1.4.0
     `);

--- a/packages/swc-angular/src/utils.ts
+++ b/packages/swc-angular/src/utils.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from 'node:fs';
+
+export class FileSystem {
+  readJsonFile<T>(path: string): T {
+    const content = readFileSync(path, 'utf-8');
+    return JSON.parse(content);
+  }
+}
+
+export const fileSystem = new FileSystem();


### PR DESCRIPTION
fallback to checking version from package.json when package doesn't export version
