### PR TITLE
fix(swc-angular): 🐞 fix invalid transform of partially compiled libs

### DIFF
--- a/packages/swc-angular-plugin/src/component_property_visitor/component_property_visitor_test.rs
+++ b/packages/swc-angular-plugin/src/component_property_visitor/component_property_visitor_test.rs
@@ -8,9 +8,11 @@ fn test_input() {
         ComponentPropertyVisitor::default(),
         indoc! {
         r#"class MyCmp {
-              myInput = input();
-              anotherProperty = 'hello';
-            }"# },
+          myInput = input();
+          anotherProperty = 'hello';
+        }
+        MyCmp = _ts_decorate([], MyCmp);
+        "# },
         indoc! {
         r#"import * as _jsc_angular_core from "@angular/core";
         class MyCmp {
@@ -22,6 +24,7 @@ fn test_input() {
                 isSignal: true
             })
         ], MyCmp.prototype, "myInput");
+        MyCmp = _ts_decorate([], MyCmp);
         "# },
     );
 }
@@ -32,8 +35,10 @@ fn test_input_required() {
         ComponentPropertyVisitor::default(),
         indoc! {
         r#"class MyCmp {
-                myInput = input.required();
-            }"# },
+            myInput = input.required();
+        }
+        MyCmp = _ts_decorate([], MyCmp);
+        "# },
         indoc! {
         r#"import * as _jsc_angular_core from "@angular/core";
         class MyCmp {
@@ -45,6 +50,7 @@ fn test_input_required() {
                 required: true
             })
         ], MyCmp.prototype, "myInput");
+        MyCmp = _ts_decorate([], MyCmp);
         "# },
     );
 }
@@ -55,13 +61,15 @@ fn test_input_alias() {
         ComponentPropertyVisitor::default(),
         indoc! {
         r#"class MyCmp {
-                aliasedInput = input(undefined, {
-                    alias: 'myInputAlias'
-                });
-                nonAliasedInput = input({
-                    alias: 'this_is_a_default_value_not_an_alias'
-                });
-            }"# },
+            aliasedInput = input(undefined, {
+                alias: 'myInputAlias'
+            });
+            nonAliasedInput = input({
+                alias: 'this_is_a_default_value_not_an_alias'
+            });
+        }
+        MyCmp = _ts_decorate([], MyCmp);
+        "# },
         indoc! {
         r#"import * as _jsc_angular_core from "@angular/core";
         class MyCmp {
@@ -83,6 +91,7 @@ fn test_input_alias() {
                 isSignal: true
             })
         ], MyCmp.prototype, "nonAliasedInput");
+        MyCmp = _ts_decorate([], MyCmp);
         "# },
     );
 }
@@ -93,10 +102,12 @@ fn test_input_required_alias() {
         ComponentPropertyVisitor::default(),
         indoc! {
         r#"class MyCmp {
-                myInput = input.required({
-                    alias: 'myInputAlias'
-                });
-            }"# },
+            myInput = input.required({
+                alias: 'myInputAlias'
+            });
+        }
+        MyCmp = _ts_decorate([], MyCmp);
+        "# },
         indoc! {
         r#"import * as _jsc_angular_core from "@angular/core";
         class MyCmp {
@@ -111,6 +122,7 @@ fn test_input_required_alias() {
                 required: true
             })
         ], MyCmp.prototype, "myInput");
+        MyCmp = _ts_decorate([], MyCmp);
         "# },
     );
 }
@@ -130,7 +142,9 @@ fn test_input_inline() {
                     class AnotherInlineClass {}
                 }
             }
-        }"# },
+        }
+        MyCmp = _ts_decorate([], MyCmp);
+        "# },
         indoc! {
         r#"import * as _jsc_angular_core from "@angular/core";
         function f() {
@@ -151,6 +165,7 @@ fn test_input_inline() {
                 })
             ], MyCmp.prototype, "aliasedInput");
         }
+        MyCmp = _ts_decorate([], MyCmp);
         "# },
     );
 }
@@ -161,9 +176,11 @@ fn test_output() {
         ComponentPropertyVisitor::default(),
         indoc! {
         r#"class MyCmp {
-                myOutput = output();
-                anotherProperty = 'hello';
-            }"# },
+            myOutput = output();
+            anotherProperty = 'hello';
+        }
+        MyCmp = _ts_decorate([], MyCmp);
+        "# },
         indoc! {
         r#"import * as _jsc_angular_core from "@angular/core";
         class MyCmp {
@@ -173,6 +190,7 @@ fn test_output() {
         _ts_decorate([
             _jsc_angular_core.Output()
         ], MyCmp.prototype, "myOutput");
+        MyCmp = _ts_decorate([], MyCmp);
         "# },
     );
 }
@@ -183,10 +201,12 @@ fn test_output_alias() {
         ComponentPropertyVisitor::default(),
         indoc! {
         r#"class MyCmp {
-                myOutput = output({
-                    alias: 'myOutputAlias'
-                });
-            }"# },
+            myOutput = output({
+                alias: 'myOutputAlias'
+            });
+        }
+        MyCmp = _ts_decorate([], MyCmp);
+        "# },
         indoc! {
         r#"import * as _jsc_angular_core from "@angular/core";
         class MyCmp {
@@ -197,6 +217,7 @@ fn test_output_alias() {
         _ts_decorate([
             _jsc_angular_core.Output('myOutputAlias')
         ], MyCmp.prototype, "myOutput");
+        MyCmp = _ts_decorate([], MyCmp);
         "# },
     );
 }
@@ -207,8 +228,10 @@ fn test_output_from_observable() {
         ComponentPropertyVisitor::default(),
         indoc! {
         r#"class MyCmp {
-                myOutput = outputFromObservable(source$);
-            }"# },
+            myOutput = outputFromObservable(source$);
+        }
+        MyCmp = _ts_decorate([], MyCmp);
+        "# },
         indoc! {
         r#"import * as _jsc_angular_core from "@angular/core";
         class MyCmp {
@@ -217,6 +240,7 @@ fn test_output_from_observable() {
         _ts_decorate([
             _jsc_angular_core.Output()
         ], MyCmp.prototype, "myOutput");
+        MyCmp = _ts_decorate([], MyCmp);
         "# },
     );
 }
@@ -227,10 +251,11 @@ fn test_output_from_observable_with_alias() {
         ComponentPropertyVisitor::default(),
         indoc! {
         r#"class MyCmp {
-                myOutput = outputFromObservable(source$, {
-                    alias: 'myOutputAlias'
-                });
-            }"# },
+            myOutput = outputFromObservable(source$, {
+                alias: 'myOutputAlias'
+            });
+        }
+        MyCmp = _ts_decorate([], MyCmp);"# },
         indoc! {
         r#"import * as _jsc_angular_core from "@angular/core";
         class MyCmp {
@@ -241,6 +266,7 @@ fn test_output_from_observable_with_alias() {
         _ts_decorate([
             _jsc_angular_core.Output('myOutputAlias')
         ], MyCmp.prototype, "myOutput");
+        MyCmp = _ts_decorate([], MyCmp);
         "# },
     );
 }
@@ -253,7 +279,8 @@ fn test_model() {
         r#"class MyCmp {
             myModel = model();
             anotherProperty = 'hello';
-        }"# },
+        }
+        MyCmp = _ts_decorate([], MyCmp);"# },
         indoc! {
         r#"import * as _jsc_angular_core from "@angular/core";
         class MyCmp {
@@ -268,6 +295,7 @@ fn test_model() {
         _ts_decorate([
             _jsc_angular_core.Output("myModelChange")
         ], MyCmp.prototype, "myModel");
+        MyCmp = _ts_decorate([], MyCmp);
         "# },
     );
 }
@@ -278,13 +306,14 @@ fn test_model_alias() {
         ComponentPropertyVisitor::default(),
         indoc! {
         r#"class MyCmp {
-                myModel = model(null, {
-                    alias: 'myModelAlias'
-                });
-                nonAliasedModel = model({
-                    alias: 'this_is_a_default_value_not_an_alias'
-                });
-            }"# },
+            myModel = model(null, {
+                alias: 'myModelAlias'
+            });
+            nonAliasedModel = model({
+                alias: 'this_is_a_default_value_not_an_alias'
+            });
+        }
+        MyCmp = _ts_decorate([], MyCmp);"# },
         indoc! {
         r#"import * as _jsc_angular_core from "@angular/core";
         class MyCmp {
@@ -312,6 +341,7 @@ fn test_model_alias() {
         _ts_decorate([
             _jsc_angular_core.Output("nonAliasedModelChange")
         ], MyCmp.prototype, "nonAliasedModel");
+        MyCmp = _ts_decorate([], MyCmp);
         "# },
     );
 }
@@ -322,8 +352,9 @@ fn test_model_required() {
         ComponentPropertyVisitor::default(),
         indoc! {
         r#"class MyCmp {
-                myModel = model.required();
-            }"# },
+            myModel = model.required();
+        }
+        MyCmp = _ts_decorate([], MyCmp);"# },
         indoc! {
         r#"import * as _jsc_angular_core from "@angular/core";
         class MyCmp {
@@ -338,6 +369,7 @@ fn test_model_required() {
         _ts_decorate([
             _jsc_angular_core.Output("myModelChange")
         ], MyCmp.prototype, "myModel");
+        MyCmp = _ts_decorate([], MyCmp);
         "# },
     );
 }
@@ -351,7 +383,8 @@ fn test_model_required_alias() {
             myModel = model.required({
                 alias: 'myModelAlias'
             });
-        }"# },
+        }
+        MyCmp = _ts_decorate([], MyCmp);"# },
         indoc! {
         r#"import * as _jsc_angular_core from "@angular/core";
         class MyCmp {
@@ -369,6 +402,7 @@ fn test_model_required_alias() {
         _ts_decorate([
             _jsc_angular_core.Output("myModelAliasChange")
         ], MyCmp.prototype, "myModel");
+        MyCmp = _ts_decorate([], MyCmp);
         "# },
     );
 }
@@ -380,7 +414,8 @@ fn test_view_child() {
         indoc! {
         r#"class MyCmp {
             titleEl = viewChild('title');
-        }"# },
+        }
+        MyCmp = _ts_decorate([], MyCmp);"# },
         indoc! {
         r#"import * as _jsc_angular_core from "@angular/core";
         class MyCmp {
@@ -391,6 +426,7 @@ fn test_view_child() {
                 isSignal: true
             })
         ], MyCmp.prototype, "titleEl");
+        MyCmp = _ts_decorate([], MyCmp);
         "# },
     );
 }
@@ -402,7 +438,8 @@ fn test_view_child_with_options() {
         indoc! {
         r#"class MyCmp {
             titleEl = viewChild('title', {read: ElementRef});
-        }"# },
+        }
+        MyCmp = _ts_decorate([], MyCmp);"# },
         indoc! {
         r#"import * as _jsc_angular_core from "@angular/core";
         class MyCmp {
@@ -416,6 +453,7 @@ fn test_view_child_with_options() {
                 isSignal: true
             })
         ], MyCmp.prototype, "titleEl");
+        MyCmp = _ts_decorate([], MyCmp);
         "# },
     );
 }
@@ -427,7 +465,8 @@ fn test_view_child_required() {
         indoc! {
         r#"class MyCmp {
             titleEl = viewChild.required('title');
-        }"# },
+        }
+        MyCmp = _ts_decorate([], MyCmp);"# },
         indoc! {
         r#"import * as _jsc_angular_core from "@angular/core";
         class MyCmp {
@@ -439,6 +478,7 @@ fn test_view_child_required() {
                 required: true
             })
         ], MyCmp.prototype, "titleEl");
+        MyCmp = _ts_decorate([], MyCmp);
         "# },
     );
 }
@@ -452,7 +492,8 @@ fn test_view_child_required_with_options() {
             titleEl = viewChild.required('title', {
                 read: ElementRef
             });
-        }"# },
+        }
+        MyCmp = _ts_decorate([], MyCmp);"# },
         indoc! {
         r#"import * as _jsc_angular_core from "@angular/core";
         class MyCmp {
@@ -467,6 +508,7 @@ fn test_view_child_required_with_options() {
                 required: true
             })
         ], MyCmp.prototype, "titleEl");
+        MyCmp = _ts_decorate([], MyCmp);
         "# },
     );
 }
@@ -478,7 +520,8 @@ fn test_view_child_component_ref() {
         indoc! {
         r#"class MyCmp {
             myComp = viewChild(MyComponent);
-        }"# },
+        }
+        MyCmp = _ts_decorate([], MyCmp);"# },
         indoc! {
         r#"import * as _jsc_angular_core from "@angular/core";
         class MyCmp {
@@ -489,6 +532,7 @@ fn test_view_child_component_ref() {
                 isSignal: true
             })
         ], MyCmp.prototype, "myComp");
+        MyCmp = _ts_decorate([], MyCmp);
         "# },
     );
 }
@@ -500,7 +544,8 @@ fn test_view_child_component_ref_with_read() {
         indoc! {
         r#"class MyCmp {
             myComp = viewChild(MyComponent, { read: MyComponent });
-        }"# },
+        }
+        MyCmp = _ts_decorate([], MyCmp);"# },
         indoc! {
         r#"import * as _jsc_angular_core from "@angular/core";
         class MyCmp {
@@ -514,6 +559,7 @@ fn test_view_child_component_ref_with_read() {
                 isSignal: true
             })
         ], MyCmp.prototype, "myComp");
+        MyCmp = _ts_decorate([], MyCmp);
         "# },
     );
 }
@@ -527,7 +573,8 @@ fn test_view_children_with_options() {
             itemEls = viewChildren('item', {
                 read: ElementRef
             });
-        }"# },
+        }
+        MyCmp = _ts_decorate([], MyCmp);"# },
         indoc! {
         r#"import * as _jsc_angular_core from "@angular/core";
         class MyCmp {
@@ -541,6 +588,7 @@ fn test_view_children_with_options() {
                 isSignal: true
             })
         ], MyCmp.prototype, "itemEls");
+        MyCmp = _ts_decorate([], MyCmp);
         "# },
     );
 }
@@ -555,7 +603,8 @@ fn test_content_child_required_with_options() {
                 descendants: true,
                 read: ElementRef
             });
-        }"# },
+        }
+        MyCmp = _ts_decorate([], MyCmp);"# },
         indoc! {
         r#"import * as _jsc_angular_core from "@angular/core";
         class MyCmp {
@@ -572,6 +621,7 @@ fn test_content_child_required_with_options() {
                 required: true
             })
         ], MyCmp.prototype, "titleEl");
+        MyCmp = _ts_decorate([], MyCmp);
         "# },
     );
 }
@@ -585,7 +635,8 @@ fn test_content_children_with_options() {
             itemEls = contentChildren('item', {
                 read: ElementRef
             });
-        }"# },
+        }
+        MyCmp = _ts_decorate([], MyCmp);"# },
         indoc! {
         r#"import * as _jsc_angular_core from "@angular/core";
         class MyCmp {
@@ -599,6 +650,7 @@ fn test_content_children_with_options() {
                 isSignal: true
             })
         ], MyCmp.prototype, "itemEls");
+        MyCmp = _ts_decorate([], MyCmp);
         "# },
     );
 }
@@ -610,7 +662,8 @@ fn test_exported_class() {
         indoc! {
         r#"export class MyCmp {
             myInput = input();
-        }"# },
+        }
+        MyCmp = _ts_decorate([], MyCmp);"# },
         indoc! {
         r#"import * as _jsc_angular_core from "@angular/core";
         export class MyCmp {
@@ -621,6 +674,7 @@ fn test_exported_class() {
                 isSignal: true
             })
         ], MyCmp.prototype, "myInput");
+        MyCmp = _ts_decorate([], MyCmp);
         "# },
     );
 }
@@ -630,11 +684,38 @@ fn test_do_not_add_angular_core_if_not_necessary() {
     test_visitor(
         ComponentPropertyVisitor::default(),
         indoc! {
-        r#"export class MyCmp {
+        r"class MyCmp {
+        }
+        MyCmp = _ts_decorate([], MyCmp);
+        " },
+        indoc! {
+        r#"class MyCmp {
+        }
+        MyCmp = _ts_decorate([], MyCmp);
+        "# },
+    );
+}
+
+#[test]
+/* Angular libraries are already partially compiled (i.e. decorators are removed,
+ * and the classes are already decorated properly) so we don't need to transform them.
+ *
+ * It would probably be more thorough to collect classes that are decorated during a visitor
+ * and then only transform those classes, but the quick workaround is to simply check
+ * if `_ts_decorate` is used.
+ *
+ * Cf. https://github.com/jscutlery/devkit/issues/677 */
+fn test_do_not_transform_if_file_already_partially_compiled() {
+    test_visitor(
+        ComponentPropertyVisitor::default(),
+        indoc! {
+        r#"class MyCmp {
+            myInput = input();
         }
         "# },
         indoc! {
-        r#"export class MyCmp {
+        r#"class MyCmp {
+            myInput = input();
         }
         "# },
     );


### PR DESCRIPTION
Angular libraries are already partially compiled (i.e. decorators are removed,
and the classes are already decorated properly) so we don't need to transform them.
It would probably be more thorough to collect classes that are decorated during a visitor
and then only transform those classes, but the quick workaround is to simply check
if `_ts_decorate` is used.

Closes #677
