### PR TITLE
fix(swc-angular-plugin): make lifetime explicit in parse_query_prop_info return type

### DIFF
--- a/packages/swc-angular-plugin/src/component_property_visitor/query_prop_parser.rs
+++ b/packages/swc-angular-plugin/src/component_property_visitor/query_prop_parser.rs
@@ -37,7 +37,7 @@ impl AngularPropParser for QueryPropParser {
 }
 
 impl QueryPropParser {
-    fn parse_query_prop_info(class_prop: &ClassProp) -> Option<(QueryType, AngularPropInfo)> {
+    fn parse_query_prop_info(class_prop: &ClassProp) -> Option<(QueryType, AngularPropInfo<'_>)> {
         /* `viewChild` & `viewChildren` are probably more frequently used so let's
          * try to parse them first. */
         if let Some(prop_info) = parse_angular_prop(class_prop, "viewChild") {


### PR DESCRIPTION
Fixes failing CI for: https://github.com/jscutlery/devkit/pull/802

Rust CI is failing to build https://github.com/jscutlery/devkit/pull/802. The function `parse_query_prop_info` returned `AngularPropInfo` with an elided lifetime, while the input `&ClassProp` provided the borrow. This inconsistency triggered the lint.

Updated the return type to `AngularPropInfo<'_>` to explicitly tie the lifetime of the returned value to the input borrow, removing the warning and unifying local and CI builds.

This makes the lifetime contract explicit.

Once this is merged the SWC update branch can be rebased and should pass then we can get swc updated!